### PR TITLE
Make most weapons lockable by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,5 +36,7 @@ How long lockouts last by default, in seconds. Default is `5`.
 When a player is about to be alerted of a locked weapon, it will wait this many seconds to allow for additional alerts to stack up, combining together instead of sending a bunch individually. Default is `0.2`.
 
 ## Config
-- `CFCWeaponLockouts.LOCKABLE`
-A list of weapon classes which are lockable. Defined in [sv_base.lua](https://github.com/CFC-Servers/cfc_weapon_lockouts/blob/master/lua/cfc_weapon_lockouts/shared/sv_base.lua "sv_base").
+- `CFCWeaponLockouts.NOT_LOCKABLE`
+A lookup of weapon classes which are not lockable. Defined in [sh_base.lua](https://github.com/CFC-Servers/cfc_weapon_lockouts/blob/master/lua/cfc_weapon_lockouts/shared/sh_base.lua "sh_base").
+- `CFCWeaponLockouts.LOCK_DURATIONS`
+Overrides the lock durations for specific weapons. Defined in [sh_base.lua](https://github.com/CFC-Servers/cfc_weapon_lockouts/blob/master/lua/cfc_weapon_lockouts/shared/sh_base.lua "sh_base").

--- a/lua/cfc_weapon_lockouts/server/sv_locker.lua
+++ b/lua/cfc_weapon_lockouts/server/sv_locker.lua
@@ -2,9 +2,21 @@ CFCWeaponLockouts = CFCWeaponLockouts or {}
 CFCWeaponLockouts._lockWarns = {}
 CFCWeaponLockouts._backend = {}
 
+local function isNotLockable( weaponClass )
+    return CFCWeaponLockouts.NOT_LOCKABLE[weaponClass]
+end
+
+local function isLockable( weaponClass )
+    return not isNotLockable( weaponClass )
+end
+
+local function getLockoutDuration( weaponClass, duration )
+    return duration or CFCWeaponLockouts.LOCK_DURATIONS[weaponClass] or CFCWeaponLockouts.LOCKOUT_TIME:GetFloat()
+end
+
 function CFCWeaponLockouts._backend.delayUnlock( ply, wep, weaponClass, duration )
     local timerName = "CFC_WeaponLockouts_Unlock_" .. ply:SteamID() .. "_" .. weaponClass
-    duration = duration or tonumber( CFCWeaponLockouts.LOCKABLE[weaponClass] ) or CFCWeaponLockouts.LOCKOUT_TIME:GetFloat()
+    duration = getLockoutDuration( weaponClass, duration )
 
     ply.weaponLockout_Times = ply.weaponLockout_Times or {}
     ply.weaponLockout_Times[weaponClass] = SysTime() + duration
@@ -33,15 +45,13 @@ function CFCWeaponLockouts.lockByClass( ply, weaponClass, duration )
         return
     end
 
-    local classIsLockable = CFCWeaponLockouts.LOCKABLE[weaponClass]
-
-    if not classIsLockable then
+    if isNotLockable( weaponClass ) then
         error( "That weapon class cannot be locked." )
 
         return
     end
 
-    duration = duration or tonumber( classIsLockable ) or CFCWeaponLockouts.LOCKOUT_TIME:GetFloat()
+    duration = getLockoutDuration( weaponClass, duration )
     ply.weaponLockouts = ply.weaponLockouts or {}
     ply.weaponLockout_Weapons = ply.weaponLockout_Weapons or {}
     ply.weaponLockouts[weaponClass] = true
@@ -78,8 +88,7 @@ function CFCWeaponLockouts._backend.lockByWeapon( ply, wep, lostWeapon, duration
     local weaponClass = wep:GetClass()
     local weaponIsValid = IsValid( wep ) and wep:IsWeapon()
     local playerIsValid = ply:IsPlayer() and ply:Alive()
-    local weaponIsLockable = CFCWeaponLockouts.LOCKABLE[weaponClass]
-    local canLock = weaponIsValid and playerIsValid and weaponIsLockable
+    local canLock = weaponIsValid and playerIsValid and isLockable( weaponClass )
 
     if not canLock then return end
 
@@ -99,7 +108,7 @@ function CFCWeaponLockouts._backend.lockByWeapon( ply, wep, lostWeapon, duration
     net.WriteString( weaponClass )
     net.Broadcast()
 
-    duration = duration or tonumber( weaponIsLockable ) or CFCWeaponLockouts.LOCKOUT_TIME:GetFloat()
+    duration = getLockoutDuration( weaponClass, duration )
 
     CFCWeaponLockouts._backend.delayUnlock( ply, wep, weaponClass, duration )
 end
@@ -114,7 +123,7 @@ function CFCWeaponLockouts._backend.updateLockStatus( ply, wep, weaponClass )
 
     -- In certain cases, EntityRemoved gets called after WeaponEquip, causing odd behavior where the weapon is unlocked, meant to be locked, and not held by the player.
     -- Manually keeping track of the weapon classes held by a player allows us to catch that error.
-    if not isLocked and plyWeapons[weaponClass] and CFCWeaponLockouts.LOCKABLE[weaponClass] then
+    if not isLocked and plyWeapons[weaponClass] and isLockable( weaponClass ) then
         isLocked = true
         CFCWeaponLockouts._backend.lockByWeapon( ply, wep, false )
     end

--- a/lua/cfc_weapon_lockouts/shared/sh_base.lua
+++ b/lua/cfc_weapon_lockouts/shared/sh_base.lua
@@ -47,31 +47,133 @@ CFCWeaponLockouts.WARN_BUILDUP = CreateConVar(
     50000
 )
 
--- If value is a number instead of true, it will specify that class' default lock duration.
-CFCWeaponLockouts.LOCKABLE = {
-    -- RPGs and similar weapons:
-    weapon_rpg = true,
-    ins2_atow_rpg7 = true,
-    m9k_rpg7 = true,
-    glide_homing_launcher = true,
-    cfc_stinger_launcher = true,
+-- Weapons that should never be locked out.
+CFCWeaponLockouts.NOT_LOCKABLE = {
+    -- GMod:
+    gmod_camera = true,
+    gmod_tool = true,
+    weapon_fists = true,
+    weapon_physgun = true,
 
-    -- Long-reload weapons (in general or compared to their peers):
-    cw_tr09_aresshrike = true,
-    m9k_minigun = true,
-    m9k_ares_shrike = true,
-    m9k_m249lmg = true,
-    m9k_m60 = true,
-    m9k_pkm = true,
-    m9k_barret_m82 = true,
-    m9k_psg1 = true,
-    m9k_svu = true,
-    m9k_svt40 = true,
-    weapon_m249 = true,
+    -- HL2:
+    weapon_bugbait = true,
+    weapon_crowbar = true,
+    weapon_frag = true,
+    weapon_physcannon = true,
+    weapon_slam = true,
+    weapon_stunstick = true,
+
+    -- HLS:
+    weapon_crowbar_hl1 = true,
+    weapon_handgrenade = true,
+    weapon_satchel = true,
+    weapon_snark = true,
+    weapon_tripmine = true,
+
+    -- CFC:
+    cfc_antigrav_grenade = true,
+    cfc_charged_cluster_grenade = true,
+    cfc_cluster_grenade = true,
+    cfc_curse_grenade = true,
+    cfc_discombob = true,
+    cfc_cinder_block = true,
+    money_gun = true,
+    cfc_prop_repair = true,
+    cfc_rotten_tomato = true,
+    cfc_weapon_shaped_charge = true,
+    cfc_slappers = true,
+    cfc_stone = true,
+    cfc_super_cluster_grenade = true,
+    cfc_super_cinder_block = true,
+    cfc_super_slappers = true,
+
+    -- CW2:
+    cw_extrema_ratio_official = true,
+    cw_flash_grenade = true,
+    cw_frag_grenade = true,
+    cw_smoke_grenade = true,
+    cw_ws_pamachete = true,
+
+    -- M9K:
+    m9k_damascus = true,
+    m9k_fists = true,
+    m9k_harpoon = true,
+    m9k_knife = true,
+    m9k_machete = true,
+    m9k_nitro = true,
+    m9k_proxy_mine = true,
+    m9k_sticky_grenade = true,
+    m9k_suicide_bomb = true,
+
+    -- PAC SWEPS:
+    pac_357 = true,
+    pac_crossbow = true,
+    pac_crowbar = true,
+    pac_dual = true,
+    pac_knife = true,
+    pac_pistol = true,
+    pac_ar2 = true,
+    pac_rpg = true,
+    pac_shotgun = true,
+    pac_slam = true,
+    pac_smg = true,
+
+    -- Wiremod:
+    laserpointer = true,
+    remotecontroller = true,
+
+    -- Simfphys:
+    weapon_simremote = true,
+    weapon_simrepair = true,
+
+    -- Glide:
+    glide_homing_launcher = true,
+    glide_repair = true,
+
+    -- Simple Weapons: CSS
+    simple_css_flashbang = true,
+    simple_css_hegrenade = true,
+    simple_css_knife = true,
+    simple_css_smokegrenade = true,
+
+    -- Simple Weapons: HL2
+    simple_hl2_crowbar = true,
+    simple_hl2_frag = true,
+    simple_hl2_stunstick = true,
+
+    -- TFA Modern Warfare
+    tfa_l4d2mw_bat = true,
+    tfa_l4d2mw_baton = true,
+    tfa_l4d2mw_crowbar = true,
+    tfa_l4d2mw_etool = true,
+    tfa_l4d2mw_fireaxe = true,
+    tfa_l4d2mw_golfclub = true,
+    tfa_l4d2mw_katana = true,
+    tfa_l4d2mw_knife = true,
+    tfa_l4d2mw_machete = true,
+    tfa_l4d2mw_metalbat = true,
+    tfa_l4d2mw_pitchfork = true,
+    tfa_l4d2mw_riotshield = true,
+    tfa_l4d2mw_shovel = true,
+    tfa_l4d2mw_sledgehammer = true,
 
     -- Misc:
-    weapon_medkit = true,
-    m9k_m98b = true
+    acf_torch = true,
+    weapon_empty_hands = true,
+    none = true,
+    weapon_crapvidcam = true,
+    keypad_cracker = true,
+}
+
+-- Allows for certain weapons to have custom lockout durations.
+CFCWeaponLockouts.LOCK_DURATIONS = {
+    -- GMod:
+    weapon_medkit = 7,
+
+    -- CFC:
+    cfc_graviton_gun = 1,
+    cfc_ion_cannon = 1,
+    cfc_trash_blaster = 1,
 }
 
 include( "cfc_weapon_lockouts/server/sv_locker.lua" )


### PR DESCRIPTION
Switches lockability from a whitelist to a blacklist, and tidies up the lockability and duration checks into helper functions.